### PR TITLE
fix: Fix exception on empty VssDefinition asset file

### DIFF
--- a/vss-processor/build.gradle.kts
+++ b/vss-processor/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     kotlin("jvm")
-    `maven-publish`
     publish
 }
 

--- a/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
+++ b/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
@@ -85,7 +85,7 @@ class VssDefinitionProcessor(
             val vssDefinitionPath = vssDefinition.vssDefinitionPath
 
             val definitionFile = loadAssetFile(vssDefinitionPath)
-            if (!definitionFile.exists()) {
+            if (definitionFile == null || !definitionFile.exists()) {
                 logger.error("No VSS definition file was found!")
                 return
             }
@@ -97,13 +97,14 @@ class VssDefinitionProcessor(
         }
 
         // Uses the default file path for generated files (from the code generator) and searches for the given file.
-        private fun loadAssetFile(fileName: String): File {
-            val generationPath = codeGenerator.generatedFile.first().absolutePath
+        private fun loadAssetFile(fileName: String): File? {
+            val generatedFile = codeGenerator.generatedFile.firstOrNull() ?: return null
+            val generationPath = generatedFile.absolutePath
             val buildPath = generationPath.replaceAfter(BUILD_FOLDER_NAME, "")
             val assetsFilePath = "$buildPath/$ASSETS_BUILD_DIRECTORY"
             val assetsFolder = File(assetsFilePath)
 
-            return assetsFolder.walk().first { it.name == fileName }
+            return assetsFolder.walk().firstOrNull { it.name == fileName }
         }
 
         private fun generateModelFiles(vssPathToSpecification: Map<VssPath, VssSpecificationSpecModel>) {

--- a/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
+++ b/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
@@ -86,7 +86,7 @@ class VssDefinitionProcessor(
 
             val definitionFile = loadAssetFile(vssDefinitionPath)
             if (definitionFile == null || !definitionFile.exists()) {
-                logger.error("No VSS definition file was found!")
+                logger.info("No VSS definition file was found!")
                 return
             }
 
@@ -113,7 +113,7 @@ class VssDefinitionProcessor(
                 .filter { it.value.size > 1 }
                 .keys
 
-            logger.logging("Ambiguous specifications - Generate nested classes: $duplicateSpecificationNames")
+            logger.info("Ambiguous specifications - Generate nested classes: $duplicateSpecificationNames")
 
             for ((vssPath, specModel) in vssPathToSpecification) {
                 // Every duplicate is produced as a nested class - No separate file should be generated

--- a/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
+++ b/vss-processor/src/main/kotlin/org/eclipse/kuksa/vssprocessor/VssDefinitionProcessor.kt
@@ -81,7 +81,7 @@ class VssDefinitionProcessor(
                 annotatedProcessorFileName,
             )
 
-            val vssDefinition = classDeclaration.getAnnotationsByType(VssDefinition::class).first()
+            val vssDefinition = classDeclaration.getAnnotationsByType(VssDefinition::class).firstOrNull() ?: return
             val vssDefinitionPath = vssDefinition.vssDefinitionPath
 
             val definitionFile = loadAssetFile(vssDefinitionPath)


### PR DESCRIPTION
If the VssDefinition annotation is missing but the processor is executed then the necessary asset file can't be found.

The current loadAssets workaround will result into a ksp error if
only tasks like kspDebug are executed. The reason is that the build
folder does not have the information from the assets folder (from
the tests or apps build command) yet.

- Removes a redundant `maven-publish` plugin

close #43