### PR TITLE
Update Dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,7 @@ import org.eclipse.kuksa.version.VERSION_FILE_DEFAULT_PATH_KEY
 
 plugins {
     id("com.android.application")
-    id("org.eclipse.velocitas.vss-processor-plugin") version "0.1.1"
+    id("org.eclipse.velocitas.vss-processor-plugin") version "0.1.2"
     kotlin("plugin.serialization")
     kotlin("android")
 }
@@ -170,8 +170,4 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.constraintlayout.compose)
-}
-
-afterEvaluate {
-    tasks.getByName("generateVssModels").notCompatibleWithConfigurationCache("")
 }

--- a/app/src/main/kotlin/org/eclipse/kuksa/testapp/KuksaDataBrokerActivity.kt
+++ b/app/src/main/kotlin/org/eclipse/kuksa/testapp/KuksaDataBrokerActivity.kt
@@ -65,11 +65,9 @@ import org.eclipse.kuksa.testapp.databroker.vsspaths.viewmodel.VSSPathsViewModel
 import org.eclipse.kuksa.testapp.extension.TAG
 import org.eclipse.kuksa.testapp.preferences.ConnectionInfoRepository
 import org.eclipse.kuksa.testapp.ui.theme.KuksaAppAndroidTheme
-import org.eclipse.kuksa.vsscore.annotation.VssModelGenerator
 import org.eclipse.kuksa.vsscore.model.VssNode
 import org.eclipse.velocitas.vss.VssVehicle
 
-@VssModelGenerator
 class KuksaDataBrokerActivity : ComponentActivity() {
     private lateinit var connectionInfoRepository: ConnectionInfoRepository
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,14 @@
 [versions]
-activityKtx = "1.10.0"
+activityKtx = "1.10.1"
 androidGradlePlugin = "8.6.1" # Check with detekt table first: https://detekt.dev/docs/introduction/compatibility/
 detekt = "1.23.6"
-datastore = "1.1.2"
-constraintlayoutCompose = "1.1.0"
-datastorePreferences = "1.1.2"
+datastore = "1.1.3"
+constraintlayoutCompose = "1.1.1"
+datastorePreferences = "1.1.3"
 dockerJavaCore = "3.4.1"
 kotlin = "1.9.22"
 kotlinxSerializationJson = "1.6.3"
-runtimeLivedata = "1.7.7"
+runtimeLivedata = "1.7.8"
 ktlint = "0.0" # Maintained inside ktlint.gradle.kts
 androidxAppCompat = "1.7.0"
 kotest = "5.9.1"
@@ -16,7 +16,7 @@ mockk = "1.13.7"
 androidxLifecycle = "2.8.7"
 kotlinxCoroutines = "1.8.1"
 kotlinCompilerExtension = "1.5.10"
-composeBom = "2025.01.01"
+composeBom = "2025.02.00"
 kuksaVersion = "0.3.2"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ androidxLifecycle = "2.8.7"
 kotlinxCoroutines = "1.8.1"
 kotlinCompilerExtension = "1.5.10"
 composeBom = "2025.01.01"
-kuksaVersion = "0.3.1"
+kuksaVersion = "0.3.2"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityKtx" }

--- a/kuksa-sdk/build.gradle.kts
+++ b/kuksa-sdk/build.gradle.kts
@@ -84,9 +84,7 @@ android {
 }
 
 dependencies {
-    api(libs.kuksa.java.sdk) {
-        exclude("org.apache.tomcat", "annotations-api")
-    }
+    api(libs.kuksa.java.sdk)
 
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotest)

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/authentication/DataBrokerConnectorAuthenticationTest.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/authentication/DataBrokerConnectorAuthenticationTest.kt
@@ -72,6 +72,7 @@ class DataBrokerConnectorAuthenticationTest : BehaviorSpec({
             val jwtFile = JwtType.READ_WRITE_ALL
 
             val dataBrokerConnector = dataBrokerConnectorProvider.createSecure(
+                port = databrokerContainer!!.port,
                 jwtFileStream = jwtFile.asInputStream(),
             )
 
@@ -104,6 +105,7 @@ class DataBrokerConnectorAuthenticationTest : BehaviorSpec({
         and("a secure DataBrokerConnector with a READ_ALL JWT") {
             val jwtFile = JwtType.READ_ALL
             val dataBrokerConnector = dataBrokerConnectorProvider.createSecure(
+                port = databrokerContainer!!.port,
                 jwtFileStream = jwtFile.asInputStream(),
             )
 
@@ -135,6 +137,7 @@ class DataBrokerConnectorAuthenticationTest : BehaviorSpec({
         and("a secure DataBrokerConnector with a READ_WRITE_ALL_VALUES_ONLY JWT") {
             val jwtFile = JwtType.READ_WRITE_ALL_VALUES_ONLY
             val dataBrokerConnector = dataBrokerConnectorProvider.createSecure(
+                port = databrokerContainer!!.port,
                 jwtFileStream = jwtFile.asInputStream(),
             )
 
@@ -189,6 +192,7 @@ class DataBrokerConnectorAuthenticationTest : BehaviorSpec({
 
         and("a secure DataBrokerConnector with no JWT") {
             val dataBrokerConnector = dataBrokerConnectorProvider.createSecure(
+                port = databrokerContainer!!.port,
                 jwtFileStream = null,
             )
 

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConfig.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 - 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,5 +23,5 @@ import java.util.concurrent.TimeUnit
 
 const val DATABROKER_HOST = "127.0.0.1"
 
-const val DATABROKER_TIMEOUT_SECONDS = 5L
+const val DATABROKER_TIMEOUT_SECONDS = 10L
 val DATABROKER_TIMEOUT_UNIT = TimeUnit.SECONDS

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectionTest.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectionTest.kt
@@ -63,7 +63,9 @@ class DataBrokerConnectionTest : BehaviorSpec({
 
     given("A successfully established connection to the DataBroker") {
         val dataBrokerConnectorProvider = DataBrokerConnectorProvider()
-        val connector = dataBrokerConnectorProvider.createInsecure()
+        val connector = dataBrokerConnectorProvider.createInsecure(
+            port = databrokerContainer!!.port,
+        )
         val dataBrokerConnection = connector.connect()
 
         and("A request with a valid VSS Path") {

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorProvider.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorProvider.kt
@@ -36,7 +36,7 @@ class DataBrokerConnectorProvider {
     lateinit var managedChannel: ManagedChannel
     fun createInsecure(
         host: String = DATABROKER_HOST,
-        port: Int = DATABROKER_PORT,
+        port: Int,
         jwtFileStream: InputStream? = null,
     ): DataBrokerConnector {
         managedChannel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build()
@@ -56,7 +56,7 @@ class DataBrokerConnectorProvider {
 
     fun createSecure(
         host: String = DATABROKER_HOST,
-        port: Int = DATABROKER_PORT,
+        port: Int,
         overrideAuthority: String = "",
         rootCertFileStream: InputStream = TestResourceFile("tls/CA.pem").inputStream(),
         jwtFileStream: InputStream? = JwtType.READ_WRITE_ALL.asInputStream(),

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorSecureTest.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorSecureTest.kt
@@ -52,6 +52,7 @@ class DataBrokerConnectorSecureTest : BehaviorSpec({
             val tlsCertificate = TestResourceFile("tls/CA.pem")
 
             val dataBrokerConnector = dataBrokerConnectorProvider.createSecure(
+                port = databrokerContainer!!.port,
                 rootCertFileStream = tlsCertificate.inputStream(),
             )
 

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorTest.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/DataBrokerConnectorTest.kt
@@ -47,7 +47,9 @@ class DataBrokerConnectorTest : BehaviorSpec({
         val dataBrokerConnectorProvider = DataBrokerConnectorProvider()
 
         and("an insecure DataBrokerConnector with valid Host and Port") {
-            val dataBrokerConnector = dataBrokerConnectorProvider.createInsecure()
+            val dataBrokerConnector = dataBrokerConnectorProvider.createInsecure(
+                port = databrokerContainer!!.port,
+            )
 
             `when`("Trying to establish an insecure connection") {
                 val connection = dataBrokerConnector.connect()

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/DataBrokerDockerContainer.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/DataBrokerDockerContainer.kt
@@ -35,6 +35,7 @@ import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import org.eclipse.kuksa.connectivity.databroker.DATABROKER_TIMEOUT_SECONDS
 import java.time.Duration
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 private const val KEY_PROPERTY_DATABROKER_TAG = "databroker.tag"
 private const val KEY_ENV_DATABROKER_TAG = "DATABROKER_TAG"
@@ -62,8 +63,9 @@ private const val DEFAULT_DATABROKER_TAG = "main"
  */
 abstract class DataBrokerDockerContainer(
     protected val containerName: String,
-    protected val port: Int,
 ) {
+    val port: Int = atomicPortNumber.getAndIncrement()
+
     protected open val hostConfig: HostConfig = HostConfig.newHostConfig()
         .withNetworkMode("host")
         .withAutoRemove(true)
@@ -134,9 +136,13 @@ abstract class DataBrokerDockerContainer(
 
             dockerClient.waitContainerCmd(containerId)
                 .exec(WaitContainerResultCallback())
-                .awaitCompletion(5, TimeUnit.SECONDS)
+                .awaitCompletion(10, TimeUnit.SECONDS)
         } catch (_: NotModifiedException) {
             // thrown when a container is already started
         }
+    }
+
+    companion object {
+        private val atomicPortNumber = AtomicInteger(55560)
     }
 }

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/InsecureDataBrokerDockerContainer.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/InsecureDataBrokerDockerContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 - 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,18 +21,16 @@ package org.eclipse.kuksa.connectivity.databroker.docker
 
 import com.github.dockerjava.api.command.CreateContainerResponse
 import org.eclipse.kuksa.connectivity.databroker.DATABROKER_CONTAINER_NAME
-import org.eclipse.kuksa.connectivity.databroker.DATABROKER_PORT
 
 // no tls, no authentication
 class InsecureDataBrokerDockerContainer(
     containerName: String = DATABROKER_CONTAINER_NAME,
-    port: Int = DATABROKER_PORT,
-) : DataBrokerDockerContainer(containerName, port) {
+) : DataBrokerDockerContainer(containerName) {
 
     @Suppress("ArgumentListWrapping", "ktlint:standard:argument-list-wrapping") // better key-value pair readability
     override fun createContainer(tag: String): CreateContainerResponse {
         return dockerClient.createContainerCmd("$repository:$tag")
-            .withName(containerName)
+            .withName("${containerName}_${System.nanoTime()}")
             .withHostConfig(hostConfig)
             .withCmd(
                 "--port", "$port",

--- a/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/SecureDataBrokerDockerContainer.kt
+++ b/kuksa-sdk/src/test/kotlin/org/eclipse/kuksa/connectivity/databroker/docker/SecureDataBrokerDockerContainer.kt
@@ -25,14 +25,12 @@ import com.github.dockerjava.api.model.Bind
 import com.github.dockerjava.api.model.HostConfig
 import com.github.dockerjava.api.model.Volume
 import org.eclipse.kuksa.connectivity.databroker.DATABROKER_CONTAINER_NAME
-import org.eclipse.kuksa.connectivity.databroker.DATABROKER_PORT
 import org.eclipse.kuksa.test.TestResourceFile
 
 // tls enabled, authentication enabled
 class SecureDataBrokerDockerContainer(
     containerName: String = DATABROKER_CONTAINER_NAME,
-    port: Int = DATABROKER_PORT,
-) : DataBrokerDockerContainer(containerName, port) {
+) : DataBrokerDockerContainer(containerName) {
 
     private val authenticationFolder = TestResourceFile("authentication").toString()
     private val authenticationMount = "/resources/authentication"
@@ -49,7 +47,7 @@ class SecureDataBrokerDockerContainer(
     @Suppress("ArgumentListWrapping", "ktlint:standard:argument-list-wrapping") // better key-value pair readability
     override fun createContainer(tag: String): CreateContainerResponse {
         return dockerClient.createContainerCmd("$repository:$tag")
-            .withName(containerName)
+            .withName("${containerName}_${System.nanoTime()}")
             .withHostConfig(hostConfig)
             .withCmd(
                 "--port", "$port",

--- a/kuksa-sdk/src/testDebug/kotlin/org/eclipse/kuksa/connectivity/databroker/DebugDataBrokerConfig.kt
+++ b/kuksa-sdk/src/testDebug/kotlin/org/eclipse/kuksa/connectivity/databroker/DebugDataBrokerConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 - 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023 - 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,5 +19,4 @@
 
 package org.eclipse.kuksa.connectivity.databroker
 
-const val DATABROKER_PORT = 55557
-const val DATABROKER_CONTAINER_NAME = "databroker_testDebug"
+const val DATABROKER_CONTAINER_NAME = "databroker_test_debug"

--- a/kuksa-sdk/src/testRelease/kotlin/org/eclipse/kuksa/connectivity/databroker/ReleaseDataBrokerConfig.kt
+++ b/kuksa-sdk/src/testRelease/kotlin/org/eclipse/kuksa/connectivity/databroker/ReleaseDataBrokerConfig.kt
@@ -18,5 +18,4 @@
 
 package org.eclipse.kuksa.connectivity.databroker
 
-const val DATABROKER_PORT = 55558
-const val DATABROKER_CONTAINER_NAME = "databroker_testRelease"
+const val DATABROKER_CONTAINER_NAME = "databroker_test_release"

--- a/samples/build.gradle.kts
+++ b/samples/build.gradle.kts
@@ -41,7 +41,7 @@ import org.eclipse.kuksa.version.VERSION_FILE_DEFAULT_PATH_KEY
 
 plugins {
     id("com.android.application")
-    id("org.eclipse.velocitas.vss-processor-plugin") version "0.1.1"
+    id("org.eclipse.velocitas.vss-processor-plugin") version "0.1.2"
     kotlin("android")
 }
 
@@ -91,8 +91,4 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.ktx)
-}
-
-afterEvaluate {
-    tasks.getByName("generateVssModels").notCompatibleWithConfigurationCache("")
 }


### PR DESCRIPTION
- Update org.eclipse.kuksa:kuksa-java-sdk to 0.3.2
-- Fixes: Dependency Clash with annotations-api
- Update org.eclipse.velocitas.vss-processor-plugin to 0.1.2
-- fix: Add Compability for JDK 11
-- fix: Configuration Cache Support
- Update misc dependencies
- Fix sporadically failing Tests